### PR TITLE
Buff m1911

### DIFF
--- a/src/resources/companions.ts
+++ b/src/resources/companions.ts
@@ -57,9 +57,9 @@ export const companions: Companion[] = [
 	},
 	{
 		name: 'John the Survivalist',
-		price: 200000,
+		price: 100000,
 		maxUpgrades: 20,
-		stressPerFetch: 25,
+		stressPerFetch: 20,
 		icon: '<:john:944974268683411476>',
 		iconURL: 'https://cdn.discordapp.com/attachments/886559272660533251/944976708291919912/john.png',
 		artist: '719365897458024558'

--- a/src/resources/items/ammunition.ts
+++ b/src/resources/items/ammunition.ts
@@ -102,7 +102,7 @@ export const ammunition = ammoObject({
 		aliases: ['.45', 'acp', 'acp_fmj', '.45_fmj', 'acp_bullet', '.45_bullet'],
 		description: 'Full metal jacket .45 ACP ammunition.',
 		damage: 31,
-		penetration: 1.8,
+		penetration: 1.9,
 		ammoFor: [ranged.m1911],
 		sellPrice: 342,
 		slotsUsed: 1,

--- a/src/resources/items/ranged.ts
+++ b/src/resources/items/ranged.ts
@@ -40,7 +40,7 @@ export const ranged = rangedObject({
 		sellPrice: 388,
 		durability: 5,
 		slotsUsed: 2,
-		accuracy: 49,
+		accuracy: 55,
 		itemLevel: 8,
 		speed: 14
 	},

--- a/src/resources/locations/forest.ts
+++ b/src/resources/locations/forest.ts
@@ -10,12 +10,12 @@ export const forest: Location = {
 		npc: {
 			type: 'raider',
 			display: 'Zoro, The Mutated Scav',
-			health: 200,
+			health: 250,
 			damage: 35,
 			drops: {
-				common: [items.chainsaw],
-				uncommon: [items.paracetamol],
-				rare: [items.sacred_pendant],
+				common: [items.chainsaw,items.saiga_MK],
+				uncommon: [items.paracetamol,items['5.45x39mm_FMJ_bullet']],
+				rare: [items.sacred_pendant,items['5.45x39mm_7N24_bullet']],
 				rolls: 2
 			},
 			weapon: items.saiga_MK,
@@ -34,7 +34,7 @@ export const forest: Location = {
 			type: 'raider',
 			display: 'Cultist Hunter',
 			health: 100,
-			damage: 35,
+			damage: 30,
 			drops: {
 				common: [items.sacred_pendant, items.cloth_backpack],
 				uncommon: [items.compression_bandage],


### PR DESCRIPTION
- increase accuracy to 55%
- acp fmj does 1.9 AP

reason: m1911 should be the ideal weapon for forest boss. bumping accuracy to 55 allows it to target limbs but with aderall gives only 90% accuracy, which is good but still unreliable in fast paced boss fight so players will be encouraged to farm more fmj ammo and chainsaws if necessary. This will also make it a good weapon to start the mall with